### PR TITLE
PADV-2371 - feat: add COURSE_PUBLISHED signal in lms settings.

### DIFF
--- a/platform_plugin_aspects/apps.py
+++ b/platform_plugin_aspects/apps.py
@@ -55,6 +55,12 @@ class PlatformPluginAspectsConfig(AppConfig):
                 PluginSignals.RECEIVERS: [
                     {
                         # The name of the app's signal receiver function.
+                        PluginSignals.RECEIVER_FUNC_NAME: "receive_course_publish",
+                        # The full path to the module where the signal is defined.
+                        PluginSignals.SIGNAL_PATH: "xmodule.modulestore.django.COURSE_PUBLISHED",
+                    },
+                    {
+                        # The name of the app's signal receiver function.
                         PluginSignals.RECEIVER_FUNC_NAME: "receive_course_enrollment_changed",
                         # The full path to the module where the signal is defined.
                         PluginSignals.SIGNAL_PATH: "common.djangoapps.student.signals.signals.ENROLL_STATUS_CHANGE",

--- a/platform_plugin_aspects/signals.py
+++ b/platform_plugin_aspects/signals.py
@@ -32,7 +32,7 @@ def receive_course_publish(  # pylint: disable=unused-argument  # pragma: no cov
         dump_course_to_clickhouse,
     )
 
-    dump_course_to_clickhouse.delay(str(course_key))
+    transaction.on_commit(lambda: dump_course_to_clickhouse.delay(str(course_key)))
 
 
 def receive_course_enrollment_changed(  # pylint: disable=unused-argument  # pragma: no cover


### PR DESCRIPTION
## Ticket

- https://agile-jira.pearson.com/browse/PADV-2371

## Description

This PR adds the signal receiver of **COURSE_PUBLISHED** in the lms plugin settings.

## Changes made

- [x] Add COURSE_PUBLISHED in lms plugin setting.

## How to test

- Initiate your openedx environment
- Install the plugin
- Review the PLUGIN_SETTINGS

## Reviewers

- [x] @MAAngamarca 
