### PR TITLE
chore: handle transactions in course enrollment sink.

### DIFF
--- a/platform_plugin_aspects/signals.py
+++ b/platform_plugin_aspects/signals.py
@@ -53,10 +53,12 @@ def receive_course_enrollment_changed(  # pylint: disable=unused-argument  # pra
 
     sink = CourseEnrollmentSink(None, None)
 
-    dump_data_to_clickhouse.delay(
-        sink_module=sink.__module__,
-        sink_name=sink.__class__.__name__,
-        object_id=instance.id,
+    transaction.on_commit(
+        lambda: dump_data_to_clickhouse.delay(
+            sink_module=sink.__module__,
+            sink_name=sink.__class__.__name__,
+            object_id=instance.id,
+        )
     )
 
 


### PR DESCRIPTION
## Description

This PR adds the transaction atomic for CourseEnrollmentSink because when enrollment is performed using course operations multiple signals are launched.

## Changes made

- [x] Add transaction atomic in **receive_course_enrollment_changed**

## Reviewers

- [x] @MAAngamarca 