### PR TITLE
PADV-2577 - fix: handle course enrollment changed transaction

### DIFF
--- a/platform_plugin_aspects/signals.py
+++ b/platform_plugin_aspects/signals.py
@@ -40,26 +40,34 @@ def receive_course_enrollment_changed(  # pylint: disable=unused-argument  # pra
 ):
     """
     Receives ENROLL_STATUS_CHANGE signal and queues the dump job.
+
+    Handles the course enrollment dumping in the middle of a transaction.
+    If this gets fired before the transaction commits, the task may try to query
+    an id that doesn't exist yet and throw an error. This should postpone
+    queuing the Celery task until after the transaction is committed.
     """
-    from platform_plugin_aspects.tasks import (  # pylint: disable=import-outside-toplevel
-        dump_data_to_clickhouse,
-    )
 
-    user = kwargs.get("user")
-    course_id = kwargs.get("course_id")
+    def on_course_enrollment_changed(**kwargs):
+        """
+        Queues the CourseEnrollment dump job when the parent transaction is committed.
+        """
+        from platform_plugin_aspects.tasks import (  # pylint: disable=import-outside-toplevel
+            dump_data_to_clickhouse,
+        )
 
-    CourseEnrollment = get_model("course_enrollment")
-    instance = CourseEnrollment.objects.get(user=user, course_id=course_id)
+        user = kwargs.get("user")
+        course_id = kwargs.get("course_id")
+        CourseEnrollment = get_model("course_enrollment")
+        instance = CourseEnrollment.objects.get(user=user, course_id=course_id)
 
-    sink = CourseEnrollmentSink(None, None)
-
-    transaction.on_commit(
-        lambda: dump_data_to_clickhouse.delay(
+        sink = CourseEnrollmentSink(None, None)
+        dump_data_to_clickhouse.delay(
             sink_module=sink.__module__,
             sink_name=sink.__class__.__name__,
-            object_id=instance.id,
+            object_id=str(instance.id),
         )
-    )
+
+    transaction.on_commit(lambda: on_course_enrollment_changed(**kwargs))
 
 
 def on_user_profile_updated(instance):


### PR DESCRIPTION
## Ticket

- https://pearson.atlassian.net/browse/PADV-2577

## Description

This PR fixes race condition in receive_course_enrollment_changed where the handler queried CourseEnrollment before the surrounding DB transaction committed. This occasionally triggered DoesNotExist/inconsistent reads. The new implementation moves the DB lookup and task enqueue inside transaction.on_commit, ensuring the row exists and state is consistent. Also normalizes the task payload.

**Cherry-picked from upstream [579d083ad7c3a2c8973ee477508a7225bbdb5e50](https://github.com/openedx/platform-plugin-aspects/pull/126).**

## Changes made

- [x] Perform CourseEnrollment lookup inside the on_commit callback.
- [x] Defer Celery import to the callback (only load if commit happens).

## How to test

- Start LMS + Celery worker.
- Enroll and unenroll a user from a course via LMS (or management command that triggers ENROLL_STATUS_CHANGE).

**Confirm:**
- No CourseEnrollment.DoesNotExist/race errors in logs.
- dump_data_to_clickhouse is enqueued after the transaction commits.
- Task arg object_id is a string (see worker log/debug).

## Reviewers

- [x] @Squirrel18